### PR TITLE
標準入力のフォームを2つに変更する ref #3

### DIFF
--- a/public/run.js
+++ b/public/run.js
@@ -4,7 +4,7 @@ function runCode() {
 
   var language = $('#language').val();
   var source_code = aceEditor.getValue();
-  var input = $('#input').val();
+  var input = $('#input1').val();
 
   $.ajax({
     // '/api/run'にデータを投げる設定

--- a/public/ui.js
+++ b/public/ui.js
@@ -35,3 +35,6 @@ $('#language').on("change", function(event) {
   setEditorLanguage(this.value);
 });
 
+(function() {
+    $("#run_button").removeAttr("disabled")
+})()

--- a/public/ui.js
+++ b/public/ui.js
@@ -34,7 +34,3 @@ setEditorLanguage('ruby');
 $('#language').on("change", function(event) {
   setEditorLanguage(this.value);
 });
-
-(function() {
-    $("#run_button").removeAttr("disabled")
-})()

--- a/views/index.slim
+++ b/views/index.slim
@@ -17,11 +17,11 @@ html
       | ソースコード:
     br
     div#source_code[style="width: 100%; height: 200px; border: 1px solid;"]
-    | 標準入力
+    | 標準入力1
     br
     textarea#input1[name="input1" cols="30" rows="10" style="width: 100%; height: 50px; resize: vertical;"]
     br
-    | 標準入力
+    | 標準入力2
     br
     textarea#input2[name="input2" cols="30" rows="10" style="width: 100%; height: 50px; resize: vertical;"]
 

--- a/views/index.slim
+++ b/views/index.slim
@@ -19,11 +19,11 @@ html
     div#source_code[style="width: 100%; height: 200px; border: 1px solid;"]
     | 標準入力
     br
-    textarea#input[name="input1" cols="30" rows="10" style="width: 100%; height: 50px; resize: vertical;"]
+    textarea#input1[name="input1" cols="30" rows="10" style="width: 100%; height: 50px; resize: vertical;"]
     br
     | 標準入力
     br
-    textarea#input[name="input2" cols="30" rows="10" style="width: 100%; height: 50px; resize: vertical;"]
+    textarea#input2[name="input2" cols="30" rows="10" style="width: 100%; height: 50px; resize: vertical;"]
 
     button#run_button.btn.btn-primary
       | 実行(Ctrl+Enter)

--- a/views/index.slim
+++ b/views/index.slim
@@ -19,11 +19,11 @@ html
     div#source_code[style="width: 100%; height: 200px; border: 1px solid;"]
     | 標準入力
     br
-    textarea#input[name="" cols="30" rows="10" style="width: 100%; height: 50px; resize: vertical;"]
+    textarea#input[name="input1" cols="30" rows="10" style="width: 100%; height: 50px; resize: vertical;"]
     br
     | 標準入力
     br
-    textarea#input[name="" cols="30" rows="10" style="width: 100%; height: 50px; resize: vertical;"]
+    textarea#input[name="input2" cols="30" rows="10" style="width: 100%; height: 50px; resize: vertical;"]
 
     button#run_button.btn.btn-primary
       | 実行(Ctrl+Enter)

--- a/views/index.slim
+++ b/views/index.slim
@@ -20,6 +20,11 @@ html
     | 標準入力
     br
     textarea#input[name="" cols="30" rows="10" style="width: 100%; height: 50px; resize: vertical;"]
+    br
+    | 標準入力
+    br
+    textarea#input[name="" cols="30" rows="10" style="width: 100%; height: 50px; resize: vertical;"]
+
     button#run_button.btn.btn-primary
       | 実行(Ctrl+Enter)
     br


### PR DESCRIPTION
# What-内容説明
issue03(標準入力のフォームを2つにする)を達成するためのPRです。index.slimの内容を変更し、標準入力を2つに変更し、それに応じてui.jsを変更することで標準入力1と標準入力2の2つの入力フォームを作成。
今回は、入力フォームを2つに変更しただけであり、標準入力1の内容はプログラムで使用することができるが、標準入力2はまだ使用することができない。
# Why-背景
1つしかなかった標準入力を2つにするというお題がでたため。
# When-期限
# Who,Where,Howその他記載事項があれば