### PR TITLE
issue07 初回起動時、tmpディレクトリが存在せず実行に失敗する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-/tmp/*
+/tmp/*.c
+/tmp/*.ruby
+/tmp/*.python
+/tmp/*.in
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-/tmp/*.c
-/tmp/*.ruby
-/tmp/*.python
-/tmp/*.in
+/tmp/*
+!.keep
 


### PR DESCRIPTION
refs #7 
.gitignoreの設定が/tmp/*となっていたため、tmpファイルそのものがバージョン管理の対象から外れていました。
なので、.gitignoreを
```
/tmp/*.c
/tmp/*.ruby
/tmp/*.python
/tmp/*.in
```
のように変更しました。